### PR TITLE
Update docs website URL

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Docs website for Bootstrapper
 
-http://laravelbootstrapper.phpfogapp.com]
+http://bootstrapper.aws.af.cm/
 
 
 ## Bootstrapper Github


### PR DESCRIPTION
I found http://bootstrapper.aws.af.cm/ is more updated than http://laravelbootstrapper.phpfogapp.com/, so I assume the previous is the current docs website. 
