### PR TITLE
Update URL to documentation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,6 @@
 # Docs website for Bootstrapper
 
-http://bootstrapper.aws.af.cm/
-
+http://bootstrapper.eu1.frbit.net/
 
 ## Bootstrapper Github
 


### PR DESCRIPTION
Old URL: http://bootstrapper.aws.af.cm/ has some DNS problem